### PR TITLE
Added switch and value flag suggestions

### DIFF
--- a/Examples/src/main/java/me/fixeddev/commandflow/examples/basic/SwitchArguments.java
+++ b/Examples/src/main/java/me/fixeddev/commandflow/examples/basic/SwitchArguments.java
@@ -28,7 +28,7 @@ public class SwitchArguments {
         commandManager.execute(namespace, "test Fixed -g"); // Prints Goodbye Fixed
         // due to missing arguments.
 
-        System.out.println(String.join(",", commandManager.getSuggestions(namespace, "test -g")));
+        System.out.println(String.join(",", commandManager.getSuggestions(namespace, "test -")));
     }
 
     private static CommandManager create() {

--- a/Examples/src/main/java/me/fixeddev/commandflow/examples/basic/SwitchArguments.java
+++ b/Examples/src/main/java/me/fixeddev/commandflow/examples/basic/SwitchArguments.java
@@ -27,6 +27,8 @@ public class SwitchArguments {
         commandManager.execute(namespace, "test -g Fixed"); // Prints Goodbye Fixed
         commandManager.execute(namespace, "test Fixed -g"); // Prints Goodbye Fixed
         // due to missing arguments.
+
+        System.out.println(String.join(",", commandManager.getSuggestions(namespace, "test -g")));
     }
 
     private static CommandManager create() {

--- a/Examples/src/main/java/me/fixeddev/commandflow/examples/basic/ValueFlagArguments.java
+++ b/Examples/src/main/java/me/fixeddev/commandflow/examples/basic/ValueFlagArguments.java
@@ -26,11 +26,15 @@ public class ValueFlagArguments {
         commandManager.execute(namespace, "test Fixed"); // Prints Hi Fixed
         commandManager.execute(namespace, "test Fixed -g GoodBye"); // Prints GoodBye Fixed
         commandManager.execute(namespace, "test Fixed -g Hello"); // Prints Hello Fixed
+
+        System.out.println(String.join(",", commandManager.getSuggestions(namespace, "test -g")));
+
         commandManager.execute(namespace, "test -g Fixed"); // Throws a NoMoreArguments exception, meaning that the parsing failed
         // because the Fixed argument was taken as the value for the flag and no argument
         // is remaining for the name.
         commandManager.execute(namespace, "test Fixed -g"); // Throws a NoMoreArguments exception, meaning that the parsing failed
         // because the flag doesn't has any argument left to use.
+
     }
 
     private static CommandManager create() {

--- a/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SequentialCommandPart.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SequentialCommandPart.java
@@ -88,7 +88,7 @@ public class SequentialCommandPart implements CommandPart, PartsWrapper {
 
             List<String> suggestions = part.getSuggestions(context, stack);
 
-            if (nextString.startsWith("-")) {
+            if (nextCanBeFlag) {
                 StackSnapshot snapshot = stack.getSnapshot();
                 boolean modified = false;
 

--- a/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SequentialCommandPart.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SequentialCommandPart.java
@@ -4,22 +4,17 @@ import me.fixeddev.commandflow.CommandContext;
 import me.fixeddev.commandflow.exception.ArgumentParseException;
 import me.fixeddev.commandflow.part.CommandPart;
 import me.fixeddev.commandflow.part.PartsWrapper;
-import me.fixeddev.commandflow.part.visitor.CommandPartVisitor;
 import me.fixeddev.commandflow.stack.ArgumentStack;
 import me.fixeddev.commandflow.stack.StackSnapshot;
 import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 public class SequentialCommandPart implements CommandPart, PartsWrapper {
 

--- a/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SwitchPart.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SwitchPart.java
@@ -10,7 +10,6 @@ import net.kyori.text.TextComponent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class SwitchPart implements CommandPart {

--- a/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SwitchPart.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/SwitchPart.java
@@ -9,6 +9,7 @@ import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -85,28 +86,31 @@ public class SwitchPart implements CommandPart {
 
     @Override
     public List<String> getSuggestions(CommandContext commandContext, ArgumentStack stack) {
-        StackSnapshot snapshot = stack.getSnapshot();
+        String nextArgument = stack.hasNext() ? stack.next() : "";
 
-        while (stack.hasNext()) {
-            String arg = stack.next();
+        List<String> suggestions = new ArrayList<>();
 
-            if (!arg.startsWith("-")) {
-                continue;
-            }
-
-            if (arg.equals("--" + name) && allowFullName) {
-                stack.remove();
-                break;
-            }
-
-            if (arg.equals("-" + shortName)) {
-                stack.remove();
-                break;
-            }
+        if (!nextArgument.startsWith("-")) {
+            return suggestions;
         }
 
-        stack.applySnapshot(snapshot, false);
+        nextArgument = nextArgument.lastIndexOf('-') != 0 ? nextArgument.substring(2) : nextArgument.substring(1);
 
-        return Collections.emptyList();
+        if (allowFullName && name.startsWith(nextArgument)) {
+            suggestions.add("--" + name);
+        }
+
+        if (shortName.startsWith(nextArgument)) {
+            suggestions.add("-" + shortName);
+        }
+
+        if(nextArgument.equals(shortName) || nextArgument.equals(name)){
+            suggestions.clear();
+
+            return suggestions;
+        }
+
+        return suggestions;
     }
+
 }

--- a/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/ValueFlagPart.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/part/defaults/ValueFlagPart.java
@@ -11,6 +11,9 @@ import net.kyori.text.Component;
 import net.kyori.text.TextComponent;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class ValueFlagPart implements SinglePartWrapper {
 
     private final CommandPart part;
@@ -89,6 +92,35 @@ public class ValueFlagPart implements SinglePartWrapper {
         }
 
         stack.applySnapshot(snapshot, false);
+    }
+
+    @Override
+    public List<String> getSuggestions(CommandContext commandContext, ArgumentStack stack) {
+        String nextArgument = stack.hasNext() ? stack.next() : "";
+
+        List<String> suggestions = new ArrayList<>();
+
+        if (!nextArgument.startsWith("-")) {
+            return suggestions;
+        }
+
+        nextArgument = nextArgument.lastIndexOf('-') != 0 ? nextArgument.substring(2) : nextArgument.substring(1);
+
+        if (allowFullName&& name.startsWith(nextArgument)) {
+            suggestions.add("--" + name);
+        }
+
+        if (shortName.startsWith(nextArgument)) {
+            suggestions.add("-" + shortName);
+        }
+
+        if (nextArgument.equals(shortName) || nextArgument.equals(name)) {
+            suggestions.clear();
+
+            suggestions.addAll(part.getSuggestions(commandContext, stack));
+        }
+
+        return suggestions;
     }
 
     private boolean parseValueFlag(CommandContext context, ArgumentStack stack) {


### PR DESCRIPTION
As suggested by #15, we added tab completion for switch and value flags only when the next argument starts with a "-".
To allow this we needed custom treatment on the SequentialCommandParts for the ValueFlagPart and SwitchPart.

More testing is needed before merging this into the main branch, since only basic testing was done before creating the pull request with the changes