### PR TITLE
chore: 0.5.3 version on universal

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Those are created using the `Command.builder(String)` method, which returns an `
 <dependency>
   <groupId>me.fixeddev</groupId>
   <artifactId>commandflow-universal</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.3</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Bumped the version of the universal dependency as it has been changed on parent's pom.xml