### PR TITLE
Fixed unregistering commands only applying to main command alias

### DIFF
--- a/Velocity/pom.xml
+++ b/Velocity/pom.xml
@@ -14,8 +14,8 @@
 
     <repositories>
         <repository>
-            <id>velocity</id>
-            <url>https://nexus.velocitypowered.com/repository/maven-public/</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
     </repositories>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.2-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/Velocity/src/main/java/me/fixeddev/commandflow/velocity/VelocityCommandManager.java
+++ b/Velocity/src/main/java/me/fixeddev/commandflow/velocity/VelocityCommandManager.java
@@ -1,5 +1,6 @@
 package me.fixeddev.commandflow.velocity;
 
+import com.velocitypowered.api.command.CommandMeta;
 import com.velocitypowered.api.proxy.ProxyServer;
 import me.fixeddev.commandflow.CommandContext;
 import me.fixeddev.commandflow.CommandManager;
@@ -98,7 +99,12 @@ public class VelocityCommandManager implements CommandManager {
         VelocityCommandWrapper velocityCommandWrapper = new VelocityCommandWrapper(command, commandManager, getTranslator());
         wrapperMap.put(command.getName(), velocityCommandWrapper);
 
-        proxyServer.getCommandManager().register(command.getName(), velocityCommandWrapper, command.getAliases().toArray(new String[0]));
+        final CommandMeta commandMeta = proxyServer.getCommandManager().metaBuilder(command.getName())
+                        .aliases(command.getAliases().toArray(new String[0]))
+                        .plugin(plugin)
+                        .build();
+
+        proxyServer.getCommandManager().register(commandMeta, velocityCommandWrapper);
     }
 
     @Override
@@ -119,7 +125,8 @@ public class VelocityCommandManager implements CommandManager {
 
         VelocityCommandWrapper velocityCommandWrapper = wrapperMap.get(command.getName());
         if (velocityCommandWrapper != null) {
-            proxyServer.getCommandManager().unregister(command.getName());
+            final CommandMeta commandMeta = proxyServer.getCommandManager().getCommandMeta(command.getName());
+            proxyServer.getCommandManager().unregister(commandMeta);
         }
     }
 


### PR DESCRIPTION
In Velocity there are 2 methods to unregister commands. [`CommandManager#unregister(String)`](https://jd.papermc.io/velocity/3.0.0/com/velocitypowered/api/command/CommandManager.html#unregister(java.lang.String)) which unregisters only the command alias in the internal CommandDispatcher and [`CommandManager#unregister(CommandMeta)`](https://jd.papermc.io/velocity/3.0.0/com/velocitypowered/api/command/CommandManager.html#unregister(com.velocitypowered.api.command.CommandMeta)) which unregisters the entire command, including its aliases

In addition, I added the reference of the plugin that registers the commands to the CommandMeta. In this way, you can check which plugin has register which command by using [`CommandMeta#getPlugin`](https://jd.papermc.io/velocity/3.0.0/com/velocitypowered/api/command/CommandMeta.html#getPlugin())