### PR TITLE
Encapsulation

### DIFF
--- a/Brigadier/src/main/java/me/fixeddev/commandflow/brigadier/PermissionRequirement.java
+++ b/Brigadier/src/main/java/me/fixeddev/commandflow/brigadier/PermissionRequirement.java
@@ -2,7 +2,6 @@ package me.fixeddev.commandflow.brigadier;
 
 import me.fixeddev.commandflow.Authorizer;
 import me.fixeddev.commandflow.Namespace;
-import me.fixeddev.commandflow.NamespaceImpl;
 import me.fixeddev.commandflow.bukkit.BukkitCommandManager;
 import me.lucko.commodore.Commodore;
 import org.bukkit.command.CommandSender;
@@ -25,7 +24,7 @@ public class PermissionRequirement implements Predicate<Object> {
     public boolean test(Object o) {
         CommandSender sender = commodore.getBukkitSender(o);
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSender.class, BukkitCommandManager.SENDER_NAMESPACE, sender);
 
         return authorizer.isAuthorized(namespace, permission);

--- a/Bukkit/src/main/java/me/fixeddev/commandflow/bukkit/BukkitCommandWrapper.java
+++ b/Bukkit/src/main/java/me/fixeddev/commandflow/bukkit/BukkitCommandWrapper.java
@@ -5,7 +5,6 @@ import me.fixeddev.commandflow.Authorizer;
 import me.fixeddev.commandflow.CommandContext;
 import me.fixeddev.commandflow.CommandManager;
 import me.fixeddev.commandflow.Namespace;
-import me.fixeddev.commandflow.NamespaceImpl;
 import me.fixeddev.commandflow.SimpleCommandContext;
 import me.fixeddev.commandflow.exception.CommandException;
 import me.fixeddev.commandflow.translator.Translator;
@@ -32,13 +31,13 @@ public class BukkitCommandWrapper extends Command {
 
         this.setAliases(command.getAliases());
 
-        CommandContext fakeContext = new SimpleCommandContext(new NamespaceImpl(), new ArrayList<>());
+        CommandContext fakeContext = new SimpleCommandContext(Namespace.create(), new ArrayList<>());
         fakeContext.setCommand(command, "<command>");
 
         this.setUsage(LegacyComponentSerializer.legacyAmpersand().serialize(dispatcher.getUsageBuilder().getUsage(fakeContext)));
 
         if (command.getDescription() != null) {
-            Component translatedDescription = translator.translate(command.getDescription(), new NamespaceImpl());
+            Component translatedDescription = translator.translate(command.getDescription(), Namespace.create());
 
             this.setDescription(LegacyComponentSerializer.legacyAmpersand().serialize(translatedDescription));
         }
@@ -59,7 +58,7 @@ public class BukkitCommandWrapper extends Command {
         argumentLine.add(label);
         argumentLine.addAll(Arrays.asList(args));
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
 
         namespace.setObject(CommandSender.class, BukkitCommandManager.SENDER_NAMESPACE, commandSender);
         namespace.setObject(String.class, "label", label);
@@ -89,7 +88,7 @@ public class BukkitCommandWrapper extends Command {
         List<String> argumentLine = new ArrayList<>(Arrays.asList(args));
         argumentLine.add(0, alias);
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSender.class, BukkitCommandManager.SENDER_NAMESPACE, sender);
 
         return commandManager.getSuggestions(namespace, argumentLine);
@@ -98,7 +97,7 @@ public class BukkitCommandWrapper extends Command {
     @Override
     public boolean testPermission(@NotNull CommandSender target) {
         if (!testPermissionSilent(target)) {
-            Namespace namespace = new NamespaceImpl();
+            Namespace namespace = Namespace.create();
             namespace.setObject(CommandSender.class, BukkitCommandManager.SENDER_NAMESPACE, target);
 
             Component translatedPermissionMessage = translator.translate(permissionMessage, namespace);
@@ -117,7 +116,7 @@ public class BukkitCommandWrapper extends Command {
     public boolean testPermissionSilent(CommandSender target) {
         Authorizer authorizer = commandManager.getAuthorizer();
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSender.class, BukkitCommandManager.SENDER_NAMESPACE, target);
 
         return authorizer.isAuthorized(namespace, getPermission());

--- a/Bungee/src/main/java/me/fixeddev/commandflow/bungee/BungeeCommandWrapper.java
+++ b/Bungee/src/main/java/me/fixeddev/commandflow/bungee/BungeeCommandWrapper.java
@@ -2,7 +2,6 @@ package me.fixeddev.commandflow.bungee;
 
 import me.fixeddev.commandflow.CommandManager;
 import me.fixeddev.commandflow.Namespace;
-import me.fixeddev.commandflow.NamespaceImpl;
 import me.fixeddev.commandflow.exception.CommandException;
 import me.fixeddev.commandflow.translator.Translator;
 import net.kyori.adventure.text.Component;
@@ -40,7 +39,7 @@ public class BungeeCommandWrapper extends Command implements TabExecutor {
         argumentLine.add(getName());
         argumentLine.addAll(Arrays.asList(args));
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSender.class, BungeeCommandManager.SENDER_NAMESPACE, commandSender);
         namespace.setObject(String.class, "label", getName());
 
@@ -72,7 +71,7 @@ public class BungeeCommandWrapper extends Command implements TabExecutor {
         List<String> argumentList = new ArrayList<>(Arrays.asList(strings));
         argumentList.add(0, getName());
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSender.class, BungeeCommandManager.SENDER_NAMESPACE, commandSender);
 
         return commandManager.getSuggestions(namespace, argumentList);

--- a/Discord/src/main/java/me/fixeddev/commandflow/discord/MessageListener.java
+++ b/Discord/src/main/java/me/fixeddev/commandflow/discord/MessageListener.java
@@ -2,7 +2,6 @@ package me.fixeddev.commandflow.discord;
 
 import me.fixeddev.commandflow.CommandManager;
 import me.fixeddev.commandflow.Namespace;
-import me.fixeddev.commandflow.NamespaceImpl;
 import me.fixeddev.commandflow.discord.utils.MessageUtils;
 import me.fixeddev.commandflow.exception.ArgumentParseException;
 import me.fixeddev.commandflow.exception.CommandException;
@@ -45,7 +44,7 @@ public class MessageListener extends ListenerAdapter {
 
         String label = rawMessage.substring(0, rawMessage.indexOf(" "));
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
 
         namespace.setObject(Message.class, DiscordCommandManager.MESSAGE_NAMESPACE, message);
         namespace.setObject(Member.class, DiscordCommandManager.MEMBER_NAMESPACE, member);

--- a/Universal/src/main/java/me/fixeddev/commandflow/NamespaceImpl.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/NamespaceImpl.java
@@ -4,7 +4,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class NamespaceImpl implements Namespace {
+final class NamespaceImpl implements Namespace {
 
     private final Map<Class<?>, Map<String, Object>> backing;
 

--- a/Universal/src/main/java/me/fixeddev/commandflow/annotated/AnnotatedCommandTreeBuilderImpl.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/annotated/AnnotatedCommandTreeBuilderImpl.java
@@ -2,7 +2,6 @@ package me.fixeddev.commandflow.annotated;
 
 import me.fixeddev.commandflow.annotated.annotation.*;
 import me.fixeddev.commandflow.annotated.builder.AnnotatedCommandBuilder;
-import me.fixeddev.commandflow.annotated.builder.AnnotatedCommandBuilderImpl;
 import me.fixeddev.commandflow.annotated.builder.CommandModifiersNode;
 import me.fixeddev.commandflow.annotated.builder.CommandPartsNode;
 import me.fixeddev.commandflow.annotated.builder.SubCommandsNode;
@@ -31,7 +30,7 @@ final class AnnotatedCommandTreeBuilderImpl implements AnnotatedCommandTreeBuild
     }
 
     AnnotatedCommandTreeBuilderImpl(PartInjector injector) {
-        builder = new AnnotatedCommandBuilderImpl(injector);
+        builder = AnnotatedCommandBuilder.create(injector);
         instanceCreator = new ReflectionInstanceCreator();
     }
 

--- a/Universal/src/main/java/me/fixeddev/commandflow/annotated/AnnotatedCommandTreeBuilderImpl.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/annotated/AnnotatedCommandTreeBuilderImpl.java
@@ -20,17 +20,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class AnnotatedCommandTreeBuilderImpl implements AnnotatedCommandTreeBuilder {
+final class AnnotatedCommandTreeBuilderImpl implements AnnotatedCommandTreeBuilder {
 
     private final AnnotatedCommandBuilder builder;
     private final SubCommandInstanceCreator instanceCreator;
 
-    public AnnotatedCommandTreeBuilderImpl(AnnotatedCommandBuilder builder, SubCommandInstanceCreator instanceCreator) {
+    AnnotatedCommandTreeBuilderImpl(AnnotatedCommandBuilder builder, SubCommandInstanceCreator instanceCreator) {
         this.builder = builder;
         this.instanceCreator = instanceCreator;
     }
 
-    public AnnotatedCommandTreeBuilderImpl(PartInjector injector) {
+    AnnotatedCommandTreeBuilderImpl(PartInjector injector) {
         builder = new AnnotatedCommandBuilderImpl(injector);
         instanceCreator = new ReflectionInstanceCreator();
     }

--- a/Universal/src/main/java/me/fixeddev/commandflow/annotated/builder/AnnotatedCommandBuilderImpl.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/annotated/builder/AnnotatedCommandBuilderImpl.java
@@ -2,11 +2,11 @@ package me.fixeddev.commandflow.annotated.builder;
 
 import me.fixeddev.commandflow.annotated.part.PartInjector;
 
-public class AnnotatedCommandBuilderImpl implements AnnotatedCommandBuilder {
+final class AnnotatedCommandBuilderImpl implements AnnotatedCommandBuilder {
 
     private final PartInjector injector;
 
-    public AnnotatedCommandBuilderImpl(PartInjector injector) {
+    AnnotatedCommandBuilderImpl(PartInjector injector) {
         this.injector = injector;
     }
 

--- a/Universal/src/main/java/me/fixeddev/commandflow/annotated/builder/CommandBuilderNodesImpl.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/annotated/builder/CommandBuilderNodesImpl.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public class CommandBuilderNodesImpl implements CommandActionNode, CommandDataNode, CommandPartsNode, SubCommandsNode, CommandModifiersNode {
+final class CommandBuilderNodesImpl implements CommandActionNode, CommandDataNode, CommandPartsNode, SubCommandsNode, CommandModifiersNode {
 
     private final Command.Builder builder;
     private final List<Command> subCommands;
@@ -48,7 +48,7 @@ public class CommandBuilderNodesImpl implements CommandActionNode, CommandDataNo
 
     private final CommandModifiers.Builder commandModifiersBuilder = CommandModifiers.builder();
 
-    public CommandBuilderNodesImpl(String name, PartInjector injector) {
+    CommandBuilderNodesImpl(String name, PartInjector injector) {
         this.builder = Command.builder(name);
         this.subCommands = new ArrayList<>();
         partGetters = new ArrayList<>();

--- a/Universal/src/main/java/me/fixeddev/commandflow/annotated/part/SimplePartInjector.java
+++ b/Universal/src/main/java/me/fixeddev/commandflow/annotated/part/SimplePartInjector.java
@@ -7,13 +7,13 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class SimplePartInjector implements PartInjector {
+final class SimplePartInjector implements PartInjector {
 
     private final Map<Key, PartFactory> factoryBindings;
     private final Map<Class<? extends Annotation>, PartModifier> modifiers;
     private final Map<Class<? extends Annotation>, CommandModifierFactory> commandModifiers;
 
-    public SimplePartInjector() {
+    SimplePartInjector() {
         this.factoryBindings = new ConcurrentHashMap<>();
         this.modifiers = new ConcurrentHashMap<>();
         this.commandModifiers = new ConcurrentHashMap<>();

--- a/Velocity/src/main/java/me/fixeddev/commandflow/velocity/VelocityCommandWrapper.java
+++ b/Velocity/src/main/java/me/fixeddev/commandflow/velocity/VelocityCommandWrapper.java
@@ -4,7 +4,6 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.command.RawCommand;
 import me.fixeddev.commandflow.CommandManager;
 import me.fixeddev.commandflow.Namespace;
-import me.fixeddev.commandflow.NamespaceImpl;
 import me.fixeddev.commandflow.command.Command;
 import me.fixeddev.commandflow.exception.CommandException;
 import me.fixeddev.commandflow.translator.Translator;
@@ -38,7 +37,7 @@ public class VelocityCommandWrapper implements RawCommand {
         CommandSource commandSource = invocation.source();
         String argumentLine = invocation.alias() + " " + invocation.arguments();
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSource.class, VelocityCommandManager.SENDER_NAMESPACE, commandSource);
         namespace.setObject(String.class, "label", invocation.alias());
 
@@ -70,7 +69,7 @@ public class VelocityCommandWrapper implements RawCommand {
         CommandSource commandSource = invocation.source();
         String argumentLine = invocation.alias() + " "+ invocation.arguments();
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSource.class, VelocityCommandManager.SENDER_NAMESPACE, commandSource);
 
         return commandManager.getSuggestions(namespace, argumentLine);
@@ -80,7 +79,7 @@ public class VelocityCommandWrapper implements RawCommand {
     public boolean hasPermission(Invocation invocation) {
         CommandSource commandSource = invocation.source();
 
-        Namespace namespace = new NamespaceImpl();
+        Namespace namespace = Namespace.create();
         namespace.setObject(CommandSource.class, VelocityCommandManager.SENDER_NAMESPACE, commandSource);
 
         return commandManager.getAuthorizer().isAuthorized(namespace, getPermission());


### PR DESCRIPTION
- Make `NamespaceImpl` final and package-private
- Make `AnnotatedCommandTreeBuilderImpl` final and package-private
- Make `SimplePartInjector` final and package-private
- Make `AnotatedCommandBuilderImpl` final and package-private
- Make `CommandBuilderNodesImpl` final and package-private

I'm pretty sure `NamespaceImpl` should be final and package-private, not sure about the others, but I can't see any usage for extending any of those classes, since none of them has any public method different from their implementing interface... well, maybe some class that changes the behavior of a single method? Even in that case, I think it should just use composition over inheritance.